### PR TITLE
fix(test): run integration tests from a clean build state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test-frontend:
 
 test-integration:
 	@echo "Running integration tests..."
-	@$(MVN) $(MVN_FLAGS) verify -DskipTests=true -DskipITs=false -Djacoco.haltOnFailure=false; rc=$$?; \
+	@$(MVN) $(MVN_FLAGS) clean verify -DskipTests=true -DskipITs=false -Djacoco.haltOnFailure=false; rc=$$?; \
 	docker ps -q --filter label=org.testcontainers=true | xargs -r docker rm -f > /dev/null 2>&1; \
 	exit $$rc
 


### PR DESCRIPTION
Changed test-integration to run from a clean build state, which fixes the stale-artifact classpath issue behind the intermittent ClassNotFoundException for org.peoplemesh.util.SkillNameNormalizer.

> **Note**: Please target the `develop` branch. Pull requests to `main` are reserved for maintainers.

## Description

test-integration target requires a clean state of the /target content

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Related Issues

Closes #

## Changes Made

- Makefile
- 
- 

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix/feature works
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's code style
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] All commits in this PR include a valid `Signed-off-by:` line (DCO)

